### PR TITLE
feat: add warn-on-missing-state configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   env: {
     browser: false,
     commonjs: true,
-    node: false,
+    node: true,
   },
   extends: ['airbnb-base', 'plugin:prettier/recommended'],
   overrides: [

--- a/README.md
+++ b/README.md
@@ -27,37 +27,37 @@ mocha-json-runner --help
 ```
 
 ```text
-mocha-json-runner [json..]
+mocha-json-runner <json>
 
 Playback JSON test results with Mocha
 
-Commands
-  mocha-json-runner debug [json..]  Playback JSON test results with Mocha
-                                                                       [default]
-
 Reporting & Output
-  --color, -c, --colors                     Force-enable color output  [boolean]
-  --diff                                    Show diff on failure
+  -c, --color, --colors                     Force-enable color output  [boolean]
+      --diff                                Show diff on failure
                                                        [boolean] [default: true]
-  --full-trace                              Display full stack traces  [boolean]
-  --growl, -G                               Enable Growl notifications [boolean]
-  --inline-diffs                            Display actual/expected differences
+      --full-trace                          Display full stack traces  [boolean]
+  -G, --growl                               Enable Growl notifications [boolean]
+      --inline-diffs                        Display actual/expected differences
                                             inline within each string  [boolean]
-  --reporter, -R                            Specify reporter to use
+  -R, --reporter                            Specify reporter to use
                                                       [string] [default: "spec"]
-  --reporter-option, --reporter-options,    Reporter-specific options
-  -O                                        (<k=v,[k1=v1,..]>)           [array]
+  -O, --reporter-option,                    Reporter-specific options
+  --reporter-options                        (<k=v,[k1=v1,..]>)           [array]
+      --warn-on-missing-state               Warn when test is missing `state`.
+                                            Outputs to stderr. If mocha was run
+                                            with `--grep` this would produce
+                                            warnings for tests not matching.
 
 File Handling
-  --require, -r  Require module                        [array] [default: (none)]
+  -r, --require  Require module                        [array] [default: (none)]
 
 Positional Arguments
   json  One file to load and playback
 
 Other Options
-  --help, -h     Show usage information & exit                         [boolean]
-  --version, -V  Show version number & exit                            [boolean]
-  --reporters    List built-in reporters & exit                        [boolean]
+  -h, --help       Show usage information & exit                       [boolean]
+  -V, --version    Show version number & exit                          [boolean]
+      --reporters  List built-in reporters & exit                      [boolean]
 ```
 
 ### Programmatically

--- a/lib/mocha-json-runner.js
+++ b/lib/mocha-json-runner.js
@@ -20,6 +20,8 @@ function findFailingHooks(hooks) {
   return [];
 }
 
+const config = { warnOnMissingState: false };
+
 /**
  *
  * @extends Mocha.Runner
@@ -113,8 +115,10 @@ class MochaJsonRunner extends Mocha.Runner {
                 } else if (failingAfterEachHooks.length > 0) {
                   this.failHooks(failingAfterEachHooks);
                   break; // skip remaining tests in suite
-                } else {
-                  throw new Error(
+                } else if (config.warnOnMissingState) {
+                  // could be a test that did not match a grep
+                  // eslint-disable-next-line no-console
+                  console.error(
                     `Unexpected test.state: ${
                       test.state
                     } and not pending. test: ${test.fullTitle()}`
@@ -151,6 +155,10 @@ class MochaJsonRunner extends Mocha.Runner {
 
       return this;
     };
+  }
+
+  static warnOnMissingState(value) {
+    config.warnOnMissingState = value;
   }
 }
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -43,7 +43,7 @@ const GROUPS = {
   CONFIG: 'Configuration',
 };
 
-exports.command = ['$0 <json..>'];
+exports.command = ['$0 <json>'];
 
 exports.describe = 'Playback JSON test results with Mocha';
 
@@ -117,6 +117,11 @@ exports.builder = (yargs) =>
         group: GROUPS.FILES,
         requiresArg: true,
       },
+      'warn-on-missing-state': {
+        description:
+          'Warn when test is missing `state`. Outputs to stderr. If mocha was run with `--grep` this would produce warnings for tests not matching.',
+        group: GROUPS.OUTPUT,
+      },
     })
     .positional('json', {
       description: 'One file to load and playback',
@@ -145,11 +150,15 @@ exports.builder = (yargs) =>
     .alias(aliases);
 
 exports.handler = (argv) => {
+  if (argv['warn-on-missing-state']) {
+    MochaJsonRunner.warnOnMissingState(true);
+  }
+
   Mocha.Runner = MochaJsonRunner;
 
   let json;
   try {
-    const file = argv.json[0];
+    const file = argv.json;
     json = fs.readFileSync(file, 'utf-8');
   } catch (err) {
     console.error('Error: No test files found');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "mocha-json-deserialize": "^1.1.1",
@@ -27,7 +27,8 @@
         "prettier": "2.3.0",
         "rewire": "^5.0.0",
         "sinon": "^10.0.0",
-        "standard-version": "^9.3.0"
+        "standard-version": "^9.3.0",
+        "test-console": "^1.1.0"
       },
       "peerDependencies": {
         "mocha": ">=6"
@@ -6690,6 +6691,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/test-console": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/test-console/-/test-console-1.1.0.tgz",
+      "integrity": "sha512-pntCc+DnxNVZxNIul3NjThWaLvIrp9GNHRMrriyFWFtq10LpbHGsagu7riq7UIZn79f9aXnKI7YgyMvf8dcKsg==",
+      "dev": true
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -12517,6 +12524,12 @@
           }
         }
       }
+    },
+    "test-console": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/test-console/-/test-console-1.1.0.tgz",
+      "integrity": "sha512-pntCc+DnxNVZxNIul3NjThWaLvIrp9GNHRMrriyFWFtq10LpbHGsagu7riq7UIZn79f9aXnKI7YgyMvf8dcKsg==",
+      "dev": true
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "prettier": "2.3.0",
     "rewire": "^5.0.0",
     "sinon": "^10.0.0",
-    "standard-version": "^9.3.0"
+    "standard-version": "^9.3.0",
+    "test-console": "^1.1.0"
   },
   "peerDependencies": {
     "mocha": ">=6"

--- a/test/mocha-json-runner.spec.js
+++ b/test/mocha-json-runner.spec.js
@@ -4,6 +4,7 @@ const rewire = require('rewire');
 const JsonSerializeReporter = require('mocha-json-serialize-reporter');
 const path = require('path');
 const sinon = require('sinon');
+const { stderr } = require('test-console');
 
 const { reporters } = Mocha;
 
@@ -180,7 +181,7 @@ describe('MochaJsonRunner', function () {
   });
 
   describe('#run', function () {
-    it('should throw when a test has an unexpected state', function () {
+    it('should throw when a test has an unexpected state with warnOnMissingState', function () {
       const runner = new MochaJsonRunner({
         suite: {
           title: '',
@@ -193,9 +194,15 @@ describe('MochaJsonRunner', function () {
         },
       });
 
-      expect(() => {
-        runner.run();
-      }).to.throw('Unexpected test.state');
+      MochaJsonRunner.warnOnMissingState(true);
+
+      expect(
+        stderr.inspectSync(() => {
+          runner.run();
+        })[0]
+      ).to.contain(
+        'Unexpected test.state: an unexpected state and not pending. test: Test with an unexpected state'
+      );
     });
   });
 


### PR DESCRIPTION
defaults to false, when true will output to stderr when test has unexpected state